### PR TITLE
Update quote-params.mdx

### DIFF
--- a/docs/aggregation-protocol/api/quote-params.mdx
+++ b/docs/aggregation-protocol/api/quote-params.mdx
@@ -112,15 +112,6 @@ sidebar_position: 5
         </td>
     </tr>
     <tr>
-        <td><code>gasLimit</code></td>
-        <td>integer</td>
-        <td>
-            maximum amount of gas for a swap;<br/>
-            should be the same for a quote and swap<br/>
-            <code>default: 11500000;</code> <code>max: 11500000;</code>
-        </td>
-    </tr>
-    <tr>
         <td><code>mainRouteParts</code></td>
         <td>integer</td>
         <td>


### PR DESCRIPTION
Removed the row because `gasLimit` is duplicated