### PR TITLE
Fixed wrong redirect

### DIFF
--- a/docs/limit-order-protocol/introduction.mdx
+++ b/docs/limit-order-protocol/introduction.mdx
@@ -29,7 +29,7 @@ For example, you can put up 2 WBTC tokens for sale at the price of 82415 DAI tok
 ### Limit order execution
 
 1. 1inch users can place their limit orders throught the 1inch [dApp](https://app.1inch.io/#/1/limit-order/WETH/DAI).
-2. The signed orders placed by the users can be fetched by anyone using the [1inch Limit Orders Liquidity Source API](./api)
+2. The signed orders placed by the users can be fetched by anyone using the [1inch Limit Orders Liquidity Source API](./api.mdx)
    to execute trades by filling the order on-chain.
 3. To fill a limit order on-chain, you need to pass the signed order to the `fillOrder` method on the contract.
    You can find the latest contract addresses [here](https://github.com/1inch/limit-order-protocol-utils/blob/master/src/limit-order-protocol.const.ts).


### PR DESCRIPTION
if you go to https://docs.1inch.io/docs/limit-order-protocol/introduction/ and try to press on 1inch Limit Orders Liquidity Source API link it will lead you to https://docs.1inch.io/docs/limit-order-protocol/introduction/api but this page doesn't exist. It should go to https://docs.1inch.io/docs/limit-order-protocol/api instead.

Note!
I honestly tried to start it locally, but there were so many errors that I couldn't. I tested it on a small demo project and this seems to be fixing the issue.
Also looking at their [official docu](https://docusaurus.io/docs/markdown-features/links) it seems that the extension should be part of the URL